### PR TITLE
Fix issue with months with only one digit

### DIFF
--- a/dist/CodiceFiscale.js
+++ b/dist/CodiceFiscale.js
@@ -157,7 +157,7 @@ CodiceFiscale.prototype.monthCode = function() {
 CodiceFiscale.prototype.dayCode = function() {
     var day = parseInt(this.generality("day"));
     day = this.generality("isMale") ? day : day + 40;
-    day = day.toString().substr(day.length - 2, 2);
+    day = ('00'+day.toString()).substring(day.toString().length);
     return day;
 };
 

--- a/source/CodiceFiscale.js
+++ b/source/CodiceFiscale.js
@@ -263,7 +263,7 @@ CodiceFiscale.prototype.dayCode = function () {
     var day = parseInt(this.generality('day'));
 
     day = (this.generality('isMale')) ? day : day + 40;
-    day = day.toString().substr(day.length - 2, 2);
+    day = ('00'+day.toString()).substring(day.toString().length);
 
     return day;
 };


### PR DESCRIPTION
Fixed an issue that returned a wrong value for the Taxcode when the value for the month was composed of only one digit